### PR TITLE
MAF column candidate names not in upper case

### DIFF
--- a/R/munge.R
+++ b/R/munge.R
@@ -96,7 +96,7 @@ munge <- function(files,hm3,trait.names=NULL,N,info.filter = .9,maf.filter=0.01)
     ##rename common MAF labels
     names1<-hold_names
     if("MAF" %in% hold_names) cat(print(paste("Interpreting the MAF column as the MAF (minor allele frequency) column.")),file=log.file,sep="\n",append=TRUE)
-    hold_names[hold_names %in% c("MAF","maf", "CEUaf", "Freq1", "EAF", "Freq1.Hapmap", "FreqAllele1HapMapCEU", "Freq.Allele1.HapMapCEU", "EFFECT_ALLELE_FREQ", "Freq.A1")] <- "MAF"
+    hold_names[hold_names %in% toupper(c("MAF","maf", "CEUaf", "Freq1", "EAF", "Freq1.Hapmap", "FreqAllele1HapMapCEU", "Freq.Allele1.HapMapCEU", "EFFECT_ALLELE_FREQ", "Freq.A1"))] <- "MAF"
     if(length(setdiff(names1,hold_names)) > 0) cat(print(paste("Interpreting the ", setdiff(names1, hold_names), " column as the MAF (minor allele frequency) column.")),file=log.file,sep="\n",append=TRUE)
     
     #Replace the origonal names


### PR DESCRIPTION
I want to start by saying, thank you for providing this very helpful package with your paper.

When matching on the column name for MAF, the vector holding the data on line 99 is not in upper case, but `hold_names` has been converted to upper case in line 28.

This would mean that for many cases, e.g. CEUaf, the MAF column would not be identified.

I propose to wrap `toupper` around the vector containing the data, since that is the minimal change for this to work correctly.

A better solution would be to factor out all of these "potential names" vectors out of the function. Then one could replace the vectors with a function call like `maf_names()` or another named vector, e.g. `maf_names`.  This would make the code more clear and concise, plus it would encapsulate the data defined by these vectors in a function or some other entity defined in a single place.