### PR TITLE
remove extra params when using inner_join()

### DIFF
--- a/R/sumstats.R
+++ b/R/sumstats.R
@@ -119,7 +119,7 @@ sumstats <- function(files,ref,trait.names=NULL,se.logit,OLS=NULL,linprob=NULL,N
     }
   }
   for(i in 1:len){
-    data.frame.out <- suppressWarnings(inner_join(data.frame.out,Output[[i]],by="SNP",all.x=F,all.y=F))
+    data.frame.out <- suppressWarnings(inner_join(data.frame.out,Output[[i]],by="SNP"))
   }
   
   end.time <- Sys.time()

--- a/R/sumstats_main.R
+++ b/R/sumstats_main.R
@@ -71,7 +71,7 @@
   .LOG("Merging file: ", filename, " with the reference file: ", ref2,file=log.file)
   b<-nrow(file)
   .LOG(b, " rows present in the full ", filename, " summary statistics file.",file=log.file)
-  file <- suppressWarnings(inner_join(ref,file,by="SNP",all.x=F,all.y=F))
+  file <- suppressWarnings(inner_join(ref,file,by="SNP"))
   .LOG((b-nrow(file)), " rows were removed from the ", filename, " summary statistics file as the rsIDs for these SNPs were not present in the reference file.",file=log.file)
   
   ##remove any rows with missing p-values


### PR DESCRIPTION
Removes the `all.x=F,all.y=F` params from an `dplyr::inner_join()` call, which are not needed. 

Fixes #63 