### PR TITLE
Update userGWAS.R to fix core detection

### DIFF
--- a/R/userGWAS.R
+++ b/R/userGWAS.R
@@ -281,10 +281,10 @@ userGWAS <- function(covstruc=NULL, SNPs=NULL, estimation="DWLS", model="", prin
   } else {
     if(is.null(cores)){
       ##if no default provided use 1 less than the total number of cores available so your computer will still function
-      int <- min(c(nrow(SNPs2), detectCores() - 1))
+      int <- min(c(nrow(SNPs), detectCores() - 1))
     }else{
       if (cores > nrow(SNPs))
-        warning(paste0("Provided number of cores was greater than number of SNPs, reverting to cores=",nrow(SNPs2)))
+        warning(paste0("Provided number of cores was greater than number of SNPs, reverting to cores=",nrow(SNPs)))
       int <- min(c(cores, nrow(SNPs)))
     }
     if(MPI){


### PR DESCRIPTION
An error occurred when running with no specified cores due to 'SNPs2' being used instead of 'SNPs' to determine core usage.