### PR TITLE
Implement correct processing of underflowing p values

### DIFF
--- a/R/sumstats.R
+++ b/R/sumstats.R
@@ -83,7 +83,7 @@ sumstats <- function(files,ref,trait.names=NULL,se.logit,OLS=NULL,linprob=NULL,N
   
   if(!parallel){
     ##note that fread is not used here as we have observed different formatting for column headers causing mismatched columns
-    files <- lapply(files, read.table, header=T, quote="\"", fill=T, na.string=c(".", NA, "NA", ""))
+    files <- lapply(files, read.table, header=T, quote="\"", fill=T, colClasses = c(P = "character"), na.string=c(".", NA, "NA", ""))
     
     .LOG("All files loaded into R!",file=log.file)
     Output <- list()


### PR DESCRIPTION
Addresses the issue described in #110. 

Essentially, `read.table` will now read the `P` column as a string, and afterwards use `Rmpfr` for variants that would underflow. 

One issue I can imagine is the column name `P` is now hard coded in `read.table`. 

